### PR TITLE
Environment Proxy Support for the load_ncbi_taxonomy.pl script

### DIFF
--- a/scripts/load_ncbi_taxonomy.pl
+++ b/scripts/load_ncbi_taxonomy.pl
@@ -196,7 +196,6 @@ Hilmar Lapp E<lt>hlapp at gmx.netE<gt>
 use strict;
 
 use DBI;
-use Net::FTP;
 use POSIX;
 use Getopt::Long;
 use LWP::UserAgent;
@@ -732,7 +731,7 @@ sub download_taxondb{
     my $ua = new LWP::UserAgent(agent => 'Mozilla/5.0');
     $ua->proxy(['http', 'ftp'] =>  $ENV{HTTP_PROXY});
     my $req = HTTP::Request->new('GET',"ftp://ftp.ncbi.nlm.nih.gov/pub/taxonomy/taxdump.tar.gz");
-    my  $res = $ua->request($req,$dir."/taxdump.tar.gz");
+    $ua->request($req,$dir."/taxdump.tar.gz") or die("Error downloading file");
 
     # unpack them; overwrite previous files, if necessary
     system("gunzip -f $dir/taxdump.tar.gz");


### PR DESCRIPTION
My institute network is behind a proxy. I have an environment proxy defined in the 
~/.bashrc file

http_proxy=http://username:password@proxy.network.com:port/
https_proxy=http://username:password@proxy.network.com:port/ 
ftp_proxy=http://username:password@proxy.network.com:port/

I removed the Perl's Net:FTP module dependency and am using LWP:UserAgent for proxy support.
